### PR TITLE
store를 immutable하게 변경

### DIFF
--- a/packages/client-todo-list/src/components/Todo/TodoList/TodoList.tsx
+++ b/packages/client-todo-list/src/components/Todo/TodoList/TodoList.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/no-array-index-key */
 import { FC, useCallback } from 'react';
 
 import classNames from 'classnames';

--- a/packages/client-todo-list/src/components/Todo/TodoList/TodoList.tsx
+++ b/packages/client-todo-list/src/components/Todo/TodoList/TodoList.tsx
@@ -34,7 +34,7 @@ const TodoList: FC<Props> = () => {
                 <button
                   type="button"
                   onClick={() => {
-                    store.setSelectedFolderIndex(folder.id);
+                    store.setSelectedFolderId(folder.id);
                   }}
                 >
                   {folder.title}

--- a/packages/client-todo-list/src/components/Todo/TodoList/TodoList.tsx
+++ b/packages/client-todo-list/src/components/Todo/TodoList/TodoList.tsx
@@ -29,7 +29,6 @@ const TodoList: FC<Props> = () => {
         <ul>
           {[...folders.values()].map((folder) => {
             return (
-              // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
               <li key={folder.id} className={classNames({ selected: selectedFolderId === folder.id })}>
                 <button
                   type="button"

--- a/packages/client-todo-list/src/components/Todo/TodoList/TodoList.tsx
+++ b/packages/client-todo-list/src/components/Todo/TodoList/TodoList.tsx
@@ -13,14 +13,14 @@ interface Props {}
 const TodoList: FC<Props> = () => {
   const [
     {
-      snapshot: { folders, selectedFolderIndex },
+      snapshot: { folders, selectedFolderId },
     },
     store,
   ] = useStore(todoStore);
 
   const getCurrentFolder = useCallback(() => {
-    return folders.find((folder) => folder.id === (selectedFolderIndex as number)) as Folder;
-  }, [folders, selectedFolderIndex]);
+    return folders.find((folder) => folder.id === (selectedFolderId as number)) as Folder;
+  }, [folders, selectedFolderId]);
 
   return (
     <div css={S.wrapperStyle}>
@@ -30,7 +30,7 @@ const TodoList: FC<Props> = () => {
           {[...folders.values()].map((folder) => {
             return (
               // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-              <li key={folder.id} className={classNames({ selected: selectedFolderIndex === folder.id })}>
+              <li key={folder.id} className={classNames({ selected: selectedFolderId === folder.id })}>
                 <button
                   type="button"
                   onClick={() => {
@@ -56,7 +56,7 @@ const TodoList: FC<Props> = () => {
       <div>
         <h1>Task</h1>
         <ul>
-          {selectedFolderIndex !== null &&
+          {selectedFolderId !== null &&
             getCurrentFolder().tasks.map((task) => {
               const { title, isCompleted } = task;
               return (

--- a/packages/client-todo-list/src/components/Todo/TodoList/TodoList.tsx
+++ b/packages/client-todo-list/src/components/Todo/TodoList/TodoList.tsx
@@ -1,10 +1,9 @@
-import { FC, useCallback } from 'react';
+import { FC } from 'react';
 
 import classNames from 'classnames';
 
 import { useStore } from 'lib/store';
 import { todoStore } from 'store/TodoStore';
-import Folder from 'models/Folder';
 
 import * as S from './style';
 
@@ -13,13 +12,10 @@ const TodoList: FC<Props> = () => {
   const [
     {
       snapshot: { folders, selectedFolderId },
+      currentFolder,
     },
     store,
   ] = useStore(todoStore);
-
-  const getCurrentFolder = useCallback(() => {
-    return folders.find((folder) => folder.id === (selectedFolderId as number)) as Folder;
-  }, [folders, selectedFolderId]);
 
   return (
     <div css={S.wrapperStyle}>
@@ -55,14 +51,15 @@ const TodoList: FC<Props> = () => {
         <h1>Task</h1>
         <ul>
           {selectedFolderId !== null &&
-            getCurrentFolder().tasks.map((task) => {
+            currentFolder &&
+            currentFolder.tasks.map((task) => {
               const { title, isCompleted } = task;
               return (
                 <li key={task.id}>
                   <button
                     type="button"
                     onClick={() => {
-                      store.toggleTask(getCurrentFolder(), task);
+                      store.toggleTask(currentFolder, task);
                     }}
                   >
                     {isCompleted ? 'complete' : 'incomplete'} {title}
@@ -71,7 +68,7 @@ const TodoList: FC<Props> = () => {
                     className="btn-remove"
                     type="button"
                     onClick={() => {
-                      store.removeTask(getCurrentFolder(), task);
+                      store.removeTask(currentFolder, task);
                     }}
                   >
                     X

--- a/packages/client-todo-list/src/components/Todo/TodoList/TodoList.tsx
+++ b/packages/client-todo-list/src/components/Todo/TodoList/TodoList.tsx
@@ -5,6 +5,7 @@ import classNames from 'classnames';
 
 import { useStore } from 'lib/store';
 import { todoStore } from 'store/TodoStore';
+import Folder from 'models/Folder';
 
 import * as S from './style';
 
@@ -18,7 +19,7 @@ const TodoList: FC<Props> = () => {
   ] = useStore(todoStore);
 
   const getCurrentFolder = useCallback(() => {
-    return folders[selectedFolderIndex as number];
+    return folders.find((folder) => folder.id === (selectedFolderIndex as number)) as Folder;
   }, [folders, selectedFolderIndex]);
 
   return (
@@ -26,14 +27,14 @@ const TodoList: FC<Props> = () => {
       <div>
         <h1>Folder</h1>
         <ul>
-          {[...folders.values()].map((folder, index) => {
+          {[...folders.values()].map((folder) => {
             return (
               // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-              <li key={index} className={classNames({ selected: selectedFolderIndex === index })}>
+              <li key={folder.id} className={classNames({ selected: selectedFolderIndex === folder.id })}>
                 <button
                   type="button"
                   onClick={() => {
-                    store.setSelectedFolderIndex(index);
+                    store.setSelectedFolderIndex(folder.id);
                   }}
                 >
                   {folder.title}
@@ -56,10 +57,10 @@ const TodoList: FC<Props> = () => {
         <h1>Task</h1>
         <ul>
           {selectedFolderIndex !== null &&
-            getCurrentFolder().tasks.map((task, index) => {
+            getCurrentFolder().tasks.map((task) => {
               const { title, isCompleted } = task;
               return (
-                <li key={index}>
+                <li key={task.id}>
                   <button
                     type="button"
                     onClick={() => {

--- a/packages/client-todo-list/src/components/Todo/TodoList/TodoList.tsx
+++ b/packages/client-todo-list/src/components/Todo/TodoList/TodoList.tsx
@@ -1,84 +1,17 @@
-import { FC } from 'react';
-
-import classNames from 'classnames';
-
-import { useStore } from 'lib/store';
-import { todoStore } from 'store/TodoStore';
+import type { FC } from 'react';
 
 import * as S from './style';
+import TodoListFolder from './TodoListFolders';
+import TodoListTask from './TodoListTasks';
 
 interface Props {}
-const TodoList: FC<Props> = () => {
-  const [
-    {
-      snapshot: { folders, selectedFolderId },
-      currentFolder,
-    },
-    store,
-  ] = useStore(todoStore);
 
+const TodoList: FC<Props> = () => {
   return (
-    <div css={S.wrapperStyle}>
-      <div>
-        <h1>Folder</h1>
-        <ul>
-          {[...folders.values()].map((folder) => {
-            return (
-              <li key={folder.id} className={classNames({ selected: selectedFolderId === folder.id })}>
-                <button
-                  type="button"
-                  onClick={() => {
-                    store.setSelectedFolderId(folder.id);
-                  }}
-                >
-                  {folder.title}
-                </button>
-                <button
-                  className="btn-remove"
-                  type="button"
-                  onClick={() => {
-                    store.removeFolder(folder);
-                  }}
-                >
-                  X
-                </button>
-              </li>
-            );
-          })}
-        </ul>
-      </div>
-      <div>
-        <h1>Task</h1>
-        <ul>
-          {selectedFolderId !== null &&
-            currentFolder &&
-            currentFolder.tasks.map((task) => {
-              const { title, isCompleted } = task;
-              return (
-                <li key={task.id}>
-                  <button
-                    type="button"
-                    onClick={() => {
-                      store.toggleTask(currentFolder, task);
-                    }}
-                  >
-                    {isCompleted ? 'complete' : 'incomplete'} {title}
-                  </button>
-                  <button
-                    className="btn-remove"
-                    type="button"
-                    onClick={() => {
-                      store.removeTask(currentFolder, task);
-                    }}
-                  >
-                    X
-                  </button>
-                </li>
-              );
-            })}
-        </ul>
-      </div>
-    </div>
+    <S.Wrapper>
+      <TodoListFolder />
+      <TodoListTask />
+    </S.Wrapper>
   );
 };
 

--- a/packages/client-todo-list/src/components/Todo/TodoList/TodoListFolders.tsx
+++ b/packages/client-todo-list/src/components/Todo/TodoList/TodoListFolders.tsx
@@ -1,0 +1,53 @@
+import type { FC } from 'react';
+
+import classNames from 'classnames';
+
+import { useStore } from 'lib/store';
+import { todoStore } from 'store/TodoStore';
+
+import * as S from './style';
+
+interface Props {}
+
+// TODO: TodoListFolders를 TodoListFolder로 변경(왜인지 모르갰는데 변경하면 에러가 뜸)
+const TodoListFolder: FC<Props> = () => {
+  const [
+    {
+      snapshot: { folders, selectedFolderId },
+    },
+    store,
+  ] = useStore(todoStore);
+
+  return (
+    <S.InnerWrapper>
+      <h1>Folder</h1>
+      <ul>
+        {[...folders.values()].map((folder) => {
+          return (
+            <li key={folder.id} className={classNames({ selected: selectedFolderId === folder.id })}>
+              <button
+                type="button"
+                onClick={() => {
+                  store.setSelectedFolderId(folder.id);
+                }}
+              >
+                {folder.title}
+              </button>
+              <button
+                className="btn-remove"
+                type="button"
+                onClick={() => {
+                  store.removeFolder(folder);
+                }}
+              >
+                X
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+    </S.InnerWrapper>
+  );
+};
+
+export default TodoListFolder;

--- a/packages/client-todo-list/src/components/Todo/TodoList/TodoListTasks.tsx
+++ b/packages/client-todo-list/src/components/Todo/TodoList/TodoListTasks.tsx
@@ -1,0 +1,54 @@
+import type { FC } from 'react';
+
+import { useStore } from 'lib/store';
+import { todoStore } from 'store/TodoStore';
+
+import * as S from './style';
+
+interface Props {}
+
+const TodoListTask: FC<Props> = () => {
+  const [
+    {
+      snapshot: { selectedFolderId },
+      currentFolder,
+    },
+    store,
+  ] = useStore(todoStore);
+
+  return (
+    <S.InnerWrapper>
+      <h1>Task</h1>
+      <ul>
+        {selectedFolderId !== null &&
+          currentFolder &&
+          currentFolder.tasks.map((task) => {
+            const { title, isCompleted } = task;
+            return (
+              <li key={task.id}>
+                <button
+                  type="button"
+                  onClick={() => {
+                    store.toggleTask(currentFolder, task);
+                  }}
+                >
+                  {isCompleted ? 'complete' : 'incomplete'} {title}
+                </button>
+                <button
+                  className="btn-remove"
+                  type="button"
+                  onClick={() => {
+                    store.removeTask(currentFolder, task);
+                  }}
+                >
+                  X
+                </button>
+              </li>
+            );
+          })}
+      </ul>
+    </S.InnerWrapper>
+  );
+};
+
+export default TodoListTask;

--- a/packages/client-todo-list/src/components/Todo/TodoList/style.tsx
+++ b/packages/client-todo-list/src/components/Todo/TodoList/style.tsx
@@ -1,6 +1,6 @@
-import { css, Theme } from '@emotion/react';
+import styled from '@emotion/styled';
 
-export const wrapperStyle = (theme: Theme) => css`
+export const Wrapper = styled.div`
   display: flex;
   margin: 20px;
   > div {
@@ -8,14 +8,20 @@ export const wrapperStyle = (theme: Theme) => css`
     flex-direction: column;
     gap: 10px;
   }
-  div:nth-of-type(1) {
+  > div:nth-of-type(1) {
     flex: 1;
   }
-  div:nth-of-type(2) {
+  > div:nth-of-type(2) {
     flex: 5;
   }
+`;
+
+export const InnerWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
   h1 {
-    ${theme.typo.titleL}
+    ${(props) => props.theme.typo.titleL}
   }
   ul {
     display: flex;
@@ -26,10 +32,10 @@ export const wrapperStyle = (theme: Theme) => css`
       gap: 10px;
       list-style: inside;
       &.selected {
-        color: ${theme.color.blue500};
+        color: ${(props) => props.theme.color.blue500};
       }
       .btn-remove {
-        color: ${theme.color.red500};
+        color: ${(props) => props.theme.color.red500};
       }
     }
   }

--- a/packages/client-todo-list/src/components/Todo/TodoListInputs/TodoListInputs.tsx
+++ b/packages/client-todo-list/src/components/Todo/TodoListInputs/TodoListInputs.tsx
@@ -12,17 +12,14 @@ interface Props {}
 const TodoListInputs: FC<Props> = () => {
   const [
     {
-      snapshot: { folders, selectedFolderId },
+      snapshot: { selectedFolderId },
+      currentFolder,
     },
     store,
   ] = useStore(todoStore);
 
   const [folderValue, setFolderValue] = useState<string>('');
   const [taskValue, setTaskValue] = useState<string>('');
-
-  const getCurrentFolder = useCallback(() => {
-    return folders.find((folder) => folder.id === (selectedFolderId as number)) as Folder;
-  }, [folders, selectedFolderId]);
 
   const handleFolderSubmit = useCallback(
     (e: FormEvent<HTMLFormElement>) => {
@@ -37,10 +34,10 @@ const TodoListInputs: FC<Props> = () => {
   const handleTaskSubmit = useCallback(
     (e: FormEvent<HTMLFormElement>) => {
       e.preventDefault();
-      store.addTask(getCurrentFolder(), new Task({ title: taskValue }));
+      store.addTask(currentFolder as Folder, new Task({ title: taskValue }));
       setTaskValue('');
     },
-    [store, getCurrentFolder, taskValue],
+    [store, currentFolder, taskValue],
   );
 
   return (

--- a/packages/client-todo-list/src/components/Todo/TodoListInputs/TodoListInputs.tsx
+++ b/packages/client-todo-list/src/components/Todo/TodoListInputs/TodoListInputs.tsx
@@ -23,7 +23,7 @@ const TodoListInputs: FC<Props> = () => {
   const handleFolderSubmit = useCallback(
     (e: FormEvent<HTMLFormElement>) => {
       e.preventDefault();
-      const folder = new Folder(folderValue);
+      const folder = new Folder({ title: folderValue });
       store.addFolder(folder);
       setFolderValue('');
     },

--- a/packages/client-todo-list/src/components/Todo/TodoListInputs/TodoListInputs.tsx
+++ b/packages/client-todo-list/src/components/Todo/TodoListInputs/TodoListInputs.tsx
@@ -12,7 +12,7 @@ interface Props {}
 const TodoListInputs: FC<Props> = () => {
   const [
     {
-      snapshot: { folders, selectedFolderIndex },
+      snapshot: { folders, selectedFolderId },
     },
     store,
   ] = useStore(todoStore);
@@ -21,8 +21,8 @@ const TodoListInputs: FC<Props> = () => {
   const [taskValue, setTaskValue] = useState<string>('');
 
   const getCurrentFolder = useCallback(() => {
-    return folders.find((folder) => folder.id === (selectedFolderIndex as number)) as Folder;
-  }, [folders, selectedFolderIndex]);
+    return folders.find((folder) => folder.id === (selectedFolderId as number)) as Folder;
+  }, [folders, selectedFolderId]);
 
   const handleFolderSubmit = useCallback(
     (e: FormEvent<HTMLFormElement>) => {
@@ -54,7 +54,7 @@ const TodoListInputs: FC<Props> = () => {
           required
         />
       </form>
-      {selectedFolderIndex !== null && (
+      {selectedFolderId !== null && (
         <form onSubmit={handleTaskSubmit}>
           <Input label="task" type="text" value={taskValue} onChange={(e) => setTaskValue(e.target.value)} required />
         </form>

--- a/packages/client-todo-list/src/components/Todo/TodoListInputs/TodoListInputs.tsx
+++ b/packages/client-todo-list/src/components/Todo/TodoListInputs/TodoListInputs.tsx
@@ -41,7 +41,7 @@ const TodoListInputs: FC<Props> = () => {
   );
 
   return (
-    <div css={S.wrapperStyle}>
+    <S.Wrapper>
       <form onSubmit={handleFolderSubmit}>
         <Input
           label="folder"
@@ -56,7 +56,7 @@ const TodoListInputs: FC<Props> = () => {
           <Input label="task" type="text" value={taskValue} onChange={(e) => setTaskValue(e.target.value)} required />
         </form>
       )}
-    </div>
+    </S.Wrapper>
   );
 };
 

--- a/packages/client-todo-list/src/components/Todo/TodoListInputs/TodoListInputs.tsx
+++ b/packages/client-todo-list/src/components/Todo/TodoListInputs/TodoListInputs.tsx
@@ -20,6 +20,10 @@ const TodoListInputs: FC<Props> = () => {
   const [folderValue, setFolderValue] = useState<string>('');
   const [taskValue, setTaskValue] = useState<string>('');
 
+  const getCurrentFolder = useCallback(() => {
+    return folders.find((folder) => folder.id === (selectedFolderIndex as number)) as Folder;
+  }, [folders, selectedFolderIndex]);
+
   const handleFolderSubmit = useCallback(
     (e: FormEvent<HTMLFormElement>) => {
       e.preventDefault();
@@ -33,10 +37,10 @@ const TodoListInputs: FC<Props> = () => {
   const handleTaskSubmit = useCallback(
     (e: FormEvent<HTMLFormElement>) => {
       e.preventDefault();
-      store.addTask(folders[selectedFolderIndex as number], new Task({ title: taskValue }));
+      store.addTask(getCurrentFolder(), new Task({ title: taskValue }));
       setTaskValue('');
     },
-    [folders, selectedFolderIndex, taskValue, store],
+    [store, getCurrentFolder, taskValue],
   );
 
   return (

--- a/packages/client-todo-list/src/components/Todo/TodoListInputs/style.tsx
+++ b/packages/client-todo-list/src/components/Todo/TodoListInputs/style.tsx
@@ -1,6 +1,6 @@
-import { css, Theme } from '@emotion/react';
+import styled from '@emotion/styled';
 
-export const wrapperStyle = (theme: Theme) => css`
+export const Wrapper = styled.div`
   display: flex;
   gap: 10px;
   .input-wrapper {
@@ -8,13 +8,13 @@ export const wrapperStyle = (theme: Theme) => css`
     flex-direction: column;
     gap: 3px;
     label {
-      ${theme.typo.labelM}
+      ${(props) => props.theme.typo.labelM}
     }
     input {
-      border: 1px solid ${theme.color.grey500};
+      border: 1px solid ${(props) => props.theme.color.grey500};
       border-radius: 10px;
       padding: 0 5px;
-      ${theme.typo.bodyM}
+      ${(props) => props.theme.typo.bodyM}
     }
   }
 `;

--- a/packages/client-todo-list/src/lib/store/utils.ts
+++ b/packages/client-todo-list/src/lib/store/utils.ts
@@ -9,15 +9,7 @@ type KeyType = string | symbol;
 
 export function areEqual(a: object, b: object) {
   const keys = Reflect.ownKeys(a);
-  return (
-    keys.length === Reflect.ownKeys(b).length &&
-    keys.every(
-      (key) =>
-        typeof Reflect.get(a, key) !== 'object' &&
-        typeof Reflect.get(b, key) !== 'object' &&
-        Reflect.get(a, key) === Reflect.get(b, key),
-    )
-  );
+  return keys.length === Reflect.ownKeys(b).length && keys.every((key) => Reflect.get(a, key) === Reflect.get(b, key));
 }
 
 export function getPrototypeOf(target: object): object {

--- a/packages/client-todo-list/src/models/Folder.spec.ts
+++ b/packages/client-todo-list/src/models/Folder.spec.ts
@@ -10,18 +10,28 @@ describe('Folder Model', () => {
   let folder: Folder;
   let task: Task;
   beforeEach(() => {
+    Folder.ID = 1;
+    Task.ID = 1;
     folder = new Folder(TITLE);
     task = new Task({ title: TITLE });
   });
 
   it('folder 생성', () => {
     expect(folder.title).toBe(TITLE);
+    expect(folder.id).toBe(1);
+  });
+
+  it('id auto increment', () => {
+    expect(folder.id).toBe(1);
+    folder = new Folder(TITLE);
+    expect(folder.id).toBe(2);
   });
 
   it('addTask', () => {
     folder = folder.addTask(task);
     expect(folder.tasks.includes(task)).toBeTruthy();
     expect(folder.tasks.length).toBe(1);
+    expect(folder.id).toBe(1);
   });
 
   it('removeTask', () => {
@@ -29,6 +39,7 @@ describe('Folder Model', () => {
     folder = folder.removeTask(task);
     expect(folder.tasks.includes(task)).toBeFalsy();
     expect(folder.tasks.length).toBe(0);
+    expect(folder.id).toBe(1);
   });
 
   it('toggleTask', () => {
@@ -36,12 +47,14 @@ describe('Folder Model', () => {
     expect(folder.tasks[0].isCompleted).toBeFalsy();
     folder = folder.toggleTask(task) as Folder;
     expect(folder.tasks[0].isCompleted).toBeTruthy();
+    expect(folder.id).toBe(1);
   });
 
   context('when getter, setter', () => {
     it('set title', () => {
       folder = folder.setTitle(TITLE2);
       expect(folder.title).toBe(TITLE2);
+      expect(folder.id).toBe(1);
     });
   });
 });

--- a/packages/client-todo-list/src/models/Folder.spec.ts
+++ b/packages/client-todo-list/src/models/Folder.spec.ts
@@ -12,7 +12,7 @@ describe('Folder Model', () => {
   beforeEach(() => {
     Folder.ID = 1;
     Task.ID = 1;
-    folder = new Folder(TITLE);
+    folder = new Folder({ title: TITLE });
     task = new Task({ title: TITLE });
   });
 
@@ -23,7 +23,7 @@ describe('Folder Model', () => {
 
   it('id auto increment', () => {
     expect(folder.id).toBe(1);
-    folder = new Folder(TITLE);
+    folder = new Folder({ title: TITLE });
     expect(folder.id).toBe(2);
   });
 

--- a/packages/client-todo-list/src/models/Folder.spec.ts
+++ b/packages/client-todo-list/src/models/Folder.spec.ts
@@ -19,21 +19,21 @@ describe('Folder Model', () => {
   });
 
   it('addTask', () => {
-    folder.addTask(task);
+    folder = folder.addTask(task);
     expect(folder.tasks.includes(task)).toBeTruthy();
     expect(folder.tasks.length).toBe(1);
   });
 
   it('removeTask', () => {
-    folder.addTask(task);
-    folder.removeTask(task);
+    folder = folder.addTask(task);
+    folder = folder.removeTask(task);
     expect(folder.tasks.includes(task)).toBeFalsy();
     expect(folder.tasks.length).toBe(0);
   });
 
   context('when getter, setter', () => {
     it('set title', () => {
-      folder.title = TITLE2;
+      folder = folder.setTitle(TITLE2);
       expect(folder.title).toBe(TITLE2);
     });
   });

--- a/packages/client-todo-list/src/models/Folder.spec.ts
+++ b/packages/client-todo-list/src/models/Folder.spec.ts
@@ -31,6 +31,13 @@ describe('Folder Model', () => {
     expect(folder.tasks.length).toBe(0);
   });
 
+  it('toggleTask', () => {
+    folder = folder.addTask(task);
+    expect(folder.tasks[0].isCompleted).toBeFalsy();
+    folder = folder.toggleTask(task) as Folder;
+    expect(folder.tasks[0].isCompleted).toBeTruthy();
+  });
+
   context('when getter, setter', () => {
     it('set title', () => {
       folder = folder.setTitle(TITLE2);

--- a/packages/client-todo-list/src/models/Folder.ts
+++ b/packages/client-todo-list/src/models/Folder.ts
@@ -20,6 +20,22 @@ class Folder {
     );
   }
 
+  public toggleTask(task: Task) {
+    const findTask = this.findTask(task);
+    if (!findTask) return;
+    return new Folder(
+      this.title,
+      this._tasks.map((_task) => {
+        if (_task === task) return findTask.toggle();
+        return _task;
+      }),
+    );
+  }
+
+  private findTask(task: Task) {
+    return this._tasks.find((_task) => _task === task);
+  }
+
   get title() {
     return this._title;
   }

--- a/packages/client-todo-list/src/models/Folder.ts
+++ b/packages/client-todo-list/src/models/Folder.ts
@@ -2,29 +2,32 @@ import Task from './Task';
 
 class Folder {
   private _title: string;
-  private _tasks: Set<Task>;
+  private _tasks: Task[];
 
-  constructor(title: string) {
+  constructor(title: string, tasks: Task[] = []) {
     this._title = title;
-    this._tasks = new Set<Task>();
+    this._tasks = tasks;
   }
 
   public addTask(task: Task) {
-    this._tasks.add(task);
+    return new Folder(this.title, [...this._tasks, task]);
   }
 
   public removeTask(task: Task) {
-    this._tasks.delete(task);
+    return new Folder(
+      this.title,
+      this._tasks.filter((_task) => _task !== task),
+    );
   }
 
   get title() {
     return this._title;
   }
-  set title(title: string) {
-    this._title = title;
+  setTitle(title: string) {
+    return new Folder(title, this._tasks);
   }
   get tasks() {
-    return [...this._tasks.values()];
+    return this._tasks;
   }
 }
 

--- a/packages/client-todo-list/src/models/Folder.ts
+++ b/packages/client-todo-list/src/models/Folder.ts
@@ -7,7 +7,7 @@ class Folder {
 
   public static ID = 1;
 
-  constructor(title: string, tasks: Task[] = [], id?: number) {
+  constructor({ title, tasks = [], id }: { title: string; tasks?: Task[]; id?: number }) {
     this._title = title;
     this._tasks = tasks;
     if (typeof id === 'number') {
@@ -19,28 +19,24 @@ class Folder {
   }
 
   public addTask(task: Task) {
-    return new Folder(this.title, [...this._tasks, task], this._id);
+    return new Folder({ title: this.title, tasks: [...this._tasks, task], id: this._id });
   }
 
   public removeTask(task: Task) {
-    return new Folder(
-      this.title,
-      this._tasks.filter((_task) => _task !== task),
-      this._id,
-    );
+    return new Folder({ title: this.title, tasks: this._tasks.filter((_task) => _task !== task), id: this._id });
   }
 
   public toggleTask(task: Task) {
     const findTask = this.findTask(task);
     if (!findTask) return;
-    return new Folder(
-      this.title,
-      this._tasks.map((_task) => {
+    return new Folder({
+      title: this.title,
+      tasks: this._tasks.map((_task) => {
         if (_task === task) return findTask.toggle();
         return _task;
       }),
-      this._id,
-    );
+      id: this._id,
+    });
   }
 
   private findTask(task: Task) {
@@ -51,7 +47,7 @@ class Folder {
     return this._title;
   }
   setTitle(title: string) {
-    return new Folder(title, this._tasks, this._id);
+    return new Folder({ title, tasks: this._tasks, id: this._id });
   }
   get tasks() {
     return this._tasks;

--- a/packages/client-todo-list/src/models/Folder.ts
+++ b/packages/client-todo-list/src/models/Folder.ts
@@ -3,20 +3,30 @@ import Task from './Task';
 class Folder {
   private _title: string;
   private _tasks: Task[];
+  private _id: number;
 
-  constructor(title: string, tasks: Task[] = []) {
+  public static ID = 1;
+
+  constructor(title: string, tasks: Task[] = [], id?: number) {
     this._title = title;
     this._tasks = tasks;
+    if (typeof id === 'number') {
+      this._id = id;
+    } else {
+      this._id = Folder.ID;
+      Folder.ID += 1;
+    }
   }
 
   public addTask(task: Task) {
-    return new Folder(this.title, [...this._tasks, task]);
+    return new Folder(this.title, [...this._tasks, task], this._id);
   }
 
   public removeTask(task: Task) {
     return new Folder(
       this.title,
       this._tasks.filter((_task) => _task !== task),
+      this._id,
     );
   }
 
@@ -29,6 +39,7 @@ class Folder {
         if (_task === task) return findTask.toggle();
         return _task;
       }),
+      this._id,
     );
   }
 
@@ -40,10 +51,13 @@ class Folder {
     return this._title;
   }
   setTitle(title: string) {
-    return new Folder(title, this._tasks);
+    return new Folder(title, this._tasks, this._id);
   }
   get tasks() {
     return this._tasks;
+  }
+  get id() {
+    return this._id;
   }
 }
 

--- a/packages/client-todo-list/src/models/Task.spec.ts
+++ b/packages/client-todo-list/src/models/Task.spec.ts
@@ -8,10 +8,21 @@ const TITLE2 = 'title2';
 describe('Task Model', () => {
   let task: Task;
 
+  beforeEach(() => {
+    Task.ID = 1;
+  });
+
   it('toggle', () => {
     task = new Task({ title: TITLE });
     task = task.toggle();
     expect(task.isCompleted).toBe(true);
+  });
+
+  it('id auto increment 확인', () => {
+    task = new Task({ title: TITLE });
+    expect(task.id).toBe(1);
+    task = new Task({ title: TITLE });
+    expect(task.id).toBe(2);
   });
 
   context('when task 생성', () => {

--- a/packages/client-todo-list/src/models/Task.spec.ts
+++ b/packages/client-todo-list/src/models/Task.spec.ts
@@ -12,19 +12,6 @@ describe('Task Model', () => {
     Task.ID = 1;
   });
 
-  it('toggle', () => {
-    task = new Task({ title: TITLE });
-    task = task.toggle();
-    expect(task.isCompleted).toBe(true);
-  });
-
-  it('id auto increment 확인', () => {
-    task = new Task({ title: TITLE });
-    expect(task.id).toBe(1);
-    task = new Task({ title: TITLE });
-    expect(task.id).toBe(2);
-  });
-
   context('when task 생성', () => {
     it('title만 넣은 경우', () => {
       task = new Task({ title: TITLE });
@@ -36,6 +23,19 @@ describe('Task Model', () => {
       expect(task.title).toBe(TITLE);
       expect(task.isCompleted).toBe(true);
     });
+  });
+
+  it('id auto increment 확인', () => {
+    task = new Task({ title: TITLE });
+    expect(task.id).toBe(1);
+    task = new Task({ title: TITLE });
+    expect(task.id).toBe(2);
+  });
+
+  it('toggle', () => {
+    task = new Task({ title: TITLE });
+    task = task.toggle();
+    expect(task.isCompleted).toBe(true);
   });
 
   context('when getter, setter', () => {

--- a/packages/client-todo-list/src/models/Task.spec.ts
+++ b/packages/client-todo-list/src/models/Task.spec.ts
@@ -46,10 +46,12 @@ describe('Task Model', () => {
     it('set title', () => {
       task = task.setTitle(TITLE2);
       expect(task.title).toBe(TITLE2);
+      expect(task.id).toBe(1);
     });
     it('set isCompleted', () => {
       task = task.setIsCompleted(true);
       expect(task.isCompleted).toBe(true);
+      expect(task.id).toBe(1);
     });
   });
 });

--- a/packages/client-todo-list/src/models/Task.spec.ts
+++ b/packages/client-todo-list/src/models/Task.spec.ts
@@ -25,7 +25,7 @@ describe('Task Model', () => {
     });
   });
 
-  it('id auto increment 확인', () => {
+  it('id auto increment', () => {
     task = new Task({ title: TITLE });
     expect(task.id).toBe(1);
     task = new Task({ title: TITLE });

--- a/packages/client-todo-list/src/models/Task.spec.ts
+++ b/packages/client-todo-list/src/models/Task.spec.ts
@@ -6,20 +6,22 @@ const TITLE = 'title';
 const TITLE2 = 'title2';
 
 describe('Task Model', () => {
+  let task: Task;
+
   it('toggle', () => {
-    const task = new Task({ title: TITLE });
-    task.toggle();
+    task = new Task({ title: TITLE });
+    task = task.toggle();
     expect(task.isCompleted).toBe(true);
   });
 
   context('when task 생성', () => {
     it('title만 넣은 경우', () => {
-      const task = new Task({ title: TITLE });
+      task = new Task({ title: TITLE });
       expect(task.title).toBe(TITLE);
       expect(task.isCompleted).toBe(false);
     });
     it('title, isCompleted를 넣은 경우', () => {
-      const task = new Task({ title: TITLE, isCompleted: true });
+      task = new Task({ title: TITLE, isCompleted: true });
       expect(task.title).toBe(TITLE);
       expect(task.isCompleted).toBe(true);
     });
@@ -31,11 +33,11 @@ describe('Task Model', () => {
       task = new Task({ title: TITLE });
     });
     it('set title', () => {
-      task.title = TITLE2;
+      task = task.setTitle(TITLE2);
       expect(task.title).toBe(TITLE2);
     });
     it('set isCompleted', () => {
-      task.isCompleted = true;
+      task = task.setIsCompleted(true);
       expect(task.isCompleted).toBe(true);
     });
   });

--- a/packages/client-todo-list/src/models/Task.ts
+++ b/packages/client-todo-list/src/models/Task.ts
@@ -8,20 +8,20 @@ class Task {
   }
 
   public toggle() {
-    this._isCompleted = !this._isCompleted;
+    return new Task({ title: this._title, isCompleted: !this._isCompleted });
   }
 
-  get title() {
+  public get title() {
     return this._title;
   }
-  set title(title: string) {
-    this._title = title;
+  public setTitle(title: string) {
+    return new Task({ title, isCompleted: this._isCompleted });
   }
-  get isCompleted() {
+  public get isCompleted() {
     return this._isCompleted;
   }
-  set isCompleted(isCompleted: boolean) {
-    this._isCompleted = isCompleted;
+  public setIsCompleted(isCompleted: boolean) {
+    return new Task({ title: this._title, isCompleted });
   }
 }
 

--- a/packages/client-todo-list/src/models/Task.ts
+++ b/packages/client-todo-list/src/models/Task.ts
@@ -1,27 +1,39 @@
 class Task {
   private _title: string;
   private _isCompleted: boolean;
+  private _id: number;
 
-  constructor({ title, isCompleted = false }: { title: string; isCompleted?: boolean }) {
+  public static ID = 1;
+
+  constructor({ title, isCompleted = false, id }: { title: string; isCompleted?: boolean; id?: number }) {
     this._title = title;
     this._isCompleted = isCompleted;
+    if (typeof id === 'number') {
+      this._id = id;
+    } else {
+      this._id = Task.ID;
+      Task.ID += 1;
+    }
   }
 
   public toggle() {
-    return new Task({ title: this._title, isCompleted: !this._isCompleted });
+    return new Task({ title: this._title, isCompleted: !this._isCompleted, id: this._id });
   }
 
   public get title() {
     return this._title;
   }
   public setTitle(title: string) {
-    return new Task({ title, isCompleted: this._isCompleted });
+    return new Task({ title, isCompleted: this._isCompleted, id: this._id });
   }
   public get isCompleted() {
     return this._isCompleted;
   }
   public setIsCompleted(isCompleted: boolean) {
-    return new Task({ title: this._title, isCompleted });
+    return new Task({ title: this._title, isCompleted, id: this._id });
+  }
+  public get id() {
+    return this._id;
   }
 }
 

--- a/packages/client-todo-list/src/pages/useSyncExternalStore/index.tsx
+++ b/packages/client-todo-list/src/pages/useSyncExternalStore/index.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react';
+import type { FC } from 'react';
 
 import { css } from '@emotion/react';
 

--- a/packages/client-todo-list/src/store/TodoStore.spec.ts
+++ b/packages/client-todo-list/src/store/TodoStore.spec.ts
@@ -15,7 +15,7 @@ describe('TodoStore', () => {
   });
 
   context('when addFolder', () => {
-    it('하나를 추가하는 경우 selectedFolderIndex는 0', () => {
+    it('하나를 추가하는 경우', () => {
       const folder = new Folder({ title: TITLE });
 
       todoStore.addFolder(folder);
@@ -25,27 +25,20 @@ describe('TodoStore', () => {
       expect(todoStore.snapshot.selectedFolderId).toBe(todoStore.snapshot.folders[0].id);
     });
 
-    it('두 개를 추가하는 경우 selectedFolderIndex는 1', () => {
-      todoStore.addFolder(new Folder({ title: TITLE }));
-      todoStore.addFolder(new Folder({ title: TITLE }));
-
-      expect(todoStore.snapshot.folders.length).toBe(2);
-      expect(todoStore.snapshot.selectedFolderId).toBe(todoStore.snapshot.folders[1].id);
-    });
-
-    it('n 개를 추가하는 경우 selectedFolderIndex는 n-1', () => {
+    it('n 개를 추가하는 경우 selectedFolderId는 마지막 folder id', () => {
       const n = 100;
       for (let i = 0; i < n; i++) {
         todoStore.addFolder(new Folder({ title: TITLE }));
       }
 
       expect(todoStore.snapshot.folders.length).toBe(n);
-      expect(todoStore.snapshot.selectedFolderId).toBe(todoStore.snapshot.folders[100 - 1].id);
+
+      expect(todoStore.snapshot.selectedFolderId).toBe(todoStore.snapshot.folders.at(-1)?.id);
     });
   });
 
   context('when removeFolder', () => {
-    it('1개에서 1개를 제거하는 경우 selectedFolderIndex는 null', () => {
+    it('1개에서 1개를 제거하는 경우 selectedFolderId는 null', () => {
       const folder = new Folder({ title: TITLE });
 
       todoStore.addFolder(folder);
@@ -59,7 +52,7 @@ describe('TodoStore', () => {
       expect(todoStore.snapshot.selectedFolderId).toBe(null);
     });
 
-    it('2개에서 1개를 제거하는 경우 selectedFolderIndex는 0', () => {
+    it('2개에서 1개를 제거하는 경우 selectedFolderId는 마지막 folder id', () => {
       const folder = new Folder({ title: TITLE });
       const folder2 = new Folder({ title: TITLE });
 
@@ -69,12 +62,12 @@ describe('TodoStore', () => {
       todoStore.removeFolder(folder);
 
       expect(todoStore.snapshot.folders.length).toBe(1);
-      expect(todoStore.snapshot.selectedFolderId).toBe(todoStore.snapshot.folders[0].id);
+      expect(todoStore.snapshot.selectedFolderId).toBe(todoStore.snapshot.folders.at(-1)?.id);
     });
   });
 
   context('when addFolder and removeFolder', () => {
-    it('1개를 추가하고 1개를 삭제하고 한개를 추가하는 경우 selectedFolderIndex는 0', () => {
+    it('1개를 추가하고 1개를 삭제하고 한개를 추가하는 경우 selectedFolderId는 마지막 folder id', () => {
       const folder = new Folder({ title: TITLE });
       expect(todoStore.snapshot.folders.length).toBe(0);
       todoStore.addFolder(folder);
@@ -86,9 +79,9 @@ describe('TodoStore', () => {
       todoStore.addFolder(folder2);
 
       expect(todoStore.snapshot.folders.length).toBe(1);
-      expect(todoStore.snapshot.selectedFolderId).toBe(todoStore.snapshot.folders[0].id);
+      expect(todoStore.snapshot.selectedFolderId).toBe(todoStore.snapshot.folders.at(-1)?.id);
     });
-    it('2개를 추가하고 1개를 삭제하고 1개를 추가하는 경우 selectedFolderIndex는 1', () => {
+    it('2개를 추가하고 1개를 삭제하고 1개를 추가하는 경우 selectedFolderId는 마지막 folder id', () => {
       const folder = new Folder({ title: TITLE });
       todoStore.addFolder(folder);
       const folder2 = new Folder({ title: TITLE });
@@ -100,7 +93,7 @@ describe('TodoStore', () => {
       todoStore.addFolder(folder3);
 
       expect(todoStore.snapshot.folders.length).toBe(2);
-      expect(todoStore.snapshot.selectedFolderId).toBe(todoStore.snapshot.folders[1].id);
+      expect(todoStore.snapshot.selectedFolderId).toBe(todoStore.snapshot.folders.at(-1)?.id);
     });
   });
 

--- a/packages/client-todo-list/src/store/TodoStore.spec.ts
+++ b/packages/client-todo-list/src/store/TodoStore.spec.ts
@@ -22,7 +22,7 @@ describe('TodoStore', () => {
 
       expect(todoStore.snapshot.folders.includes(folder)).toBeTruthy();
       expect(todoStore.snapshot.folders.length).toBe(1);
-      expect(todoStore.snapshot.selectedFolderIndex).toBe(todoStore.snapshot.folders[0].id);
+      expect(todoStore.snapshot.selectedFolderId).toBe(todoStore.snapshot.folders[0].id);
     });
 
     it('두 개를 추가하는 경우 selectedFolderIndex는 1', () => {
@@ -30,7 +30,7 @@ describe('TodoStore', () => {
       todoStore.addFolder(new Folder({ title: TITLE }));
 
       expect(todoStore.snapshot.folders.length).toBe(2);
-      expect(todoStore.snapshot.selectedFolderIndex).toBe(todoStore.snapshot.folders[1].id);
+      expect(todoStore.snapshot.selectedFolderId).toBe(todoStore.snapshot.folders[1].id);
     });
 
     it('n 개를 추가하는 경우 selectedFolderIndex는 n-1', () => {
@@ -40,7 +40,7 @@ describe('TodoStore', () => {
       }
 
       expect(todoStore.snapshot.folders.length).toBe(n);
-      expect(todoStore.snapshot.selectedFolderIndex).toBe(todoStore.snapshot.folders[100 - 1].id);
+      expect(todoStore.snapshot.selectedFolderId).toBe(todoStore.snapshot.folders[100 - 1].id);
     });
   });
 
@@ -56,7 +56,7 @@ describe('TodoStore', () => {
 
       expect(todoStore.snapshot.folders.includes(folder)).toBeFalsy();
       expect(todoStore.snapshot.folders.length).toBe(0);
-      expect(todoStore.snapshot.selectedFolderIndex).toBe(null);
+      expect(todoStore.snapshot.selectedFolderId).toBe(null);
     });
 
     it('2개에서 1개를 제거하는 경우 selectedFolderIndex는 0', () => {
@@ -69,7 +69,7 @@ describe('TodoStore', () => {
       todoStore.removeFolder(folder);
 
       expect(todoStore.snapshot.folders.length).toBe(1);
-      expect(todoStore.snapshot.selectedFolderIndex).toBe(todoStore.snapshot.folders[0].id);
+      expect(todoStore.snapshot.selectedFolderId).toBe(todoStore.snapshot.folders[0].id);
     });
   });
 
@@ -86,7 +86,7 @@ describe('TodoStore', () => {
       todoStore.addFolder(folder2);
 
       expect(todoStore.snapshot.folders.length).toBe(1);
-      expect(todoStore.snapshot.selectedFolderIndex).toBe(todoStore.snapshot.folders[0].id);
+      expect(todoStore.snapshot.selectedFolderId).toBe(todoStore.snapshot.folders[0].id);
     });
     it('2개를 추가하고 1개를 삭제하고 1개를 추가하는 경우 selectedFolderIndex는 1', () => {
       const folder = new Folder({ title: TITLE });
@@ -100,7 +100,7 @@ describe('TodoStore', () => {
       todoStore.addFolder(folder3);
 
       expect(todoStore.snapshot.folders.length).toBe(2);
-      expect(todoStore.snapshot.selectedFolderIndex).toBe(todoStore.snapshot.folders[1].id);
+      expect(todoStore.snapshot.selectedFolderId).toBe(todoStore.snapshot.folders[1].id);
     });
   });
 
@@ -144,16 +144,16 @@ describe('TodoStore', () => {
       todoStore.addFolder(folder2);
       todoStore.addFolder(folder3);
 
-      expect(todoStore.snapshot.selectedFolderIndex).toBe(todoStore.snapshot.folders[2].id);
+      expect(todoStore.snapshot.selectedFolderId).toBe(todoStore.snapshot.folders[2].id);
 
       todoStore.setSelectedFolderIndex(0);
-      expect(todoStore.snapshot.selectedFolderIndex).toBe(0);
+      expect(todoStore.snapshot.selectedFolderId).toBe(0);
 
       todoStore.setSelectedFolderIndex(1);
-      expect(todoStore.snapshot.selectedFolderIndex).toBe(1);
+      expect(todoStore.snapshot.selectedFolderId).toBe(1);
 
       todoStore.setSelectedFolderIndex(2);
-      expect(todoStore.snapshot.selectedFolderIndex).toBe(2);
+      expect(todoStore.snapshot.selectedFolderId).toBe(2);
     });
   });
 });

--- a/packages/client-todo-list/src/store/TodoStore.spec.ts
+++ b/packages/client-todo-list/src/store/TodoStore.spec.ts
@@ -7,7 +7,6 @@ const TITLE = 'title';
 
 const context = describe;
 
-// TODO: selectedFolderIndex 설명 변경
 describe('TodoStore', () => {
   let todoStore: TodoStore;
   beforeEach(() => {
@@ -148,12 +147,16 @@ describe('TodoStore', () => {
       todoStore.setSelectedFolderId(2);
       expect(todoStore.snapshot.selectedFolderId).toBe(2);
     });
-  });
-  // TODO: 테스트 추가
-  it('get currentFolder', () => {
-    const folder = new Folder({ title: TITLE });
-    todoStore.addFolder(folder);
-    expect(todoStore.currentFolder).toEqual(folder);
+
+    it('get currentFolder', () => {
+      const folder = new Folder({ title: TITLE });
+      todoStore.addFolder(folder);
+      expect(todoStore.currentFolder).toEqual(folder);
+
+      const folder2 = new Folder({ title: TITLE });
+      todoStore.addFolder(folder2);
+      expect(todoStore.currentFolder).toEqual(folder2);
+    });
   });
 });
 

--- a/packages/client-todo-list/src/store/TodoStore.spec.ts
+++ b/packages/client-todo-list/src/store/TodoStore.spec.ts
@@ -78,8 +78,11 @@ describe('TodoStore', () => {
   context('when addFolder and removeFolder', () => {
     it('1개를 추가하고 1개를 삭제하고 한개를 추가하는 경우 selectedFolderIndex는 0', () => {
       const folder = new Folder(TITLE);
+      expect(todoStore.snapshot.folders.length).toBe(0);
       todoStore.addFolder(folder);
+      expect(todoStore.snapshot.folders.length).toBe(1);
       todoStore.removeFolder(folder);
+      expect(todoStore.snapshot.folders.length).toBe(0);
 
       const folder2 = new Folder(TITLE);
       todoStore.addFolder(folder2);
@@ -104,9 +107,8 @@ describe('TodoStore', () => {
   });
 
   it('addTask', () => {
-    const folder = new Folder(TITLE);
-    todoStore.addFolder(folder);
-    todoStore.addTask(folder, new Task({ title: TITLE }));
+    todoStore.addFolder(new Folder(TITLE));
+    todoStore.addTask(todoStore.snapshot.folders[0], new Task({ title: TITLE }));
 
     const task = todoStore.snapshot.folders[0].tasks[0];
 
@@ -115,28 +117,23 @@ describe('TodoStore', () => {
   });
 
   it('removeTask', () => {
-    const folder = new Folder(TITLE);
-    todoStore.addFolder(folder);
-    todoStore.addTask(folder, new Task({ title: TITLE }));
+    todoStore.addFolder(new Folder(TITLE));
+    todoStore.addTask(todoStore.snapshot.folders[0], new Task({ title: TITLE }));
 
-    const task = todoStore.snapshot.folders[0].tasks[0];
-    todoStore.removeTask(folder, task);
+    todoStore.removeTask(todoStore.snapshot.folders[0], todoStore.snapshot.folders[0].tasks[0]);
 
     expect(todoStore.snapshot.folders[0].tasks.length).toBe(0);
   });
 
   it('toggleTask', () => {
-    const folder = new Folder(TITLE);
-    todoStore.addFolder(folder);
-    todoStore.addTask(folder, new Task({ title: TITLE }));
+    todoStore.addFolder(new Folder(TITLE));
+    todoStore.addTask(todoStore.snapshot.folders[0], new Task({ title: TITLE }));
 
-    const task = todoStore.snapshot.folders[0].tasks[0];
-
-    expect(task.isCompleted).toBeFalsy();
-    todoStore.toggleTask(folder, task);
-    expect(task.isCompleted).toBeTruthy();
-    todoStore.toggleTask(folder, task);
-    expect(task.isCompleted).toBeFalsy();
+    expect(todoStore.snapshot.folders[0].tasks[0].isCompleted).toBeFalsy();
+    todoStore.toggleTask(todoStore.snapshot.folders[0], todoStore.snapshot.folders[0].tasks[0]);
+    expect(todoStore.snapshot.folders[0].tasks[0].isCompleted).toBeTruthy();
+    todoStore.toggleTask(todoStore.snapshot.folders[0], todoStore.snapshot.folders[0].tasks[0]);
+    expect(todoStore.snapshot.folders[0].tasks[0].isCompleted).toBeFalsy();
   });
 
   context('when getter, setter', () => {

--- a/packages/client-todo-list/src/store/TodoStore.spec.ts
+++ b/packages/client-todo-list/src/store/TodoStore.spec.ts
@@ -156,4 +156,10 @@ describe('TodoStore', () => {
       expect(todoStore.snapshot.selectedFolderId).toBe(2);
     });
   });
+  // TODO: 테스트 추가
+  it('get currentFolder', () => {
+    const folder = new Folder({ title: TITLE });
+    todoStore.addFolder(folder);
+    expect(todoStore.currentFolder).toEqual(folder);
+  });
 });

--- a/packages/client-todo-list/src/store/TodoStore.spec.ts
+++ b/packages/client-todo-list/src/store/TodoStore.spec.ts
@@ -7,6 +7,7 @@ const TITLE = 'title';
 
 const context = describe;
 
+// TODO: selectedFolderIndex 설명 변경
 describe('TodoStore', () => {
   let todoStore: TodoStore;
   beforeEach(() => {
@@ -21,7 +22,7 @@ describe('TodoStore', () => {
 
       expect(todoStore.snapshot.folders.includes(folder)).toBeTruthy();
       expect(todoStore.snapshot.folders.length).toBe(1);
-      expect(todoStore.snapshot.selectedFolderIndex).toBe(0);
+      expect(todoStore.snapshot.selectedFolderIndex).toBe(todoStore.snapshot.folders[0].id);
     });
 
     it('두 개를 추가하는 경우 selectedFolderIndex는 1', () => {
@@ -29,7 +30,7 @@ describe('TodoStore', () => {
       todoStore.addFolder(new Folder({ title: TITLE }));
 
       expect(todoStore.snapshot.folders.length).toBe(2);
-      expect(todoStore.snapshot.selectedFolderIndex).toBe(1);
+      expect(todoStore.snapshot.selectedFolderIndex).toBe(todoStore.snapshot.folders[1].id);
     });
 
     it('n 개를 추가하는 경우 selectedFolderIndex는 n-1', () => {
@@ -39,7 +40,7 @@ describe('TodoStore', () => {
       }
 
       expect(todoStore.snapshot.folders.length).toBe(n);
-      expect(todoStore.snapshot.selectedFolderIndex).toBe(n - 1);
+      expect(todoStore.snapshot.selectedFolderIndex).toBe(todoStore.snapshot.folders[100 - 1].id);
     });
   });
 
@@ -68,10 +69,7 @@ describe('TodoStore', () => {
       todoStore.removeFolder(folder);
 
       expect(todoStore.snapshot.folders.length).toBe(1);
-      expect(todoStore.snapshot.selectedFolderIndex).toBe(0);
-
-      expect(todoStore.snapshot.folders.length).toBe(1);
-      expect(todoStore.snapshot.selectedFolderIndex).toBe(0);
+      expect(todoStore.snapshot.selectedFolderIndex).toBe(todoStore.snapshot.folders[0].id);
     });
   });
 
@@ -88,7 +86,7 @@ describe('TodoStore', () => {
       todoStore.addFolder(folder2);
 
       expect(todoStore.snapshot.folders.length).toBe(1);
-      expect(todoStore.snapshot.selectedFolderIndex).toBe(0);
+      expect(todoStore.snapshot.selectedFolderIndex).toBe(todoStore.snapshot.folders[0].id);
     });
     it('2개를 추가하고 1개를 삭제하고 1개를 추가하는 경우 selectedFolderIndex는 1', () => {
       const folder = new Folder({ title: TITLE });
@@ -102,7 +100,7 @@ describe('TodoStore', () => {
       todoStore.addFolder(folder3);
 
       expect(todoStore.snapshot.folders.length).toBe(2);
-      expect(todoStore.snapshot.selectedFolderIndex).toBe(1);
+      expect(todoStore.snapshot.selectedFolderIndex).toBe(todoStore.snapshot.folders[1].id);
     });
   });
 
@@ -146,7 +144,7 @@ describe('TodoStore', () => {
       todoStore.addFolder(folder2);
       todoStore.addFolder(folder3);
 
-      expect(todoStore.snapshot.selectedFolderIndex).toBe(2);
+      expect(todoStore.snapshot.selectedFolderIndex).toBe(todoStore.snapshot.folders[2].id);
 
       todoStore.setSelectedFolderIndex(0);
       expect(todoStore.snapshot.selectedFolderIndex).toBe(0);

--- a/packages/client-todo-list/src/store/TodoStore.spec.ts
+++ b/packages/client-todo-list/src/store/TodoStore.spec.ts
@@ -15,7 +15,7 @@ describe('TodoStore', () => {
 
   context('when addFolder', () => {
     it('하나를 추가하는 경우 selectedFolderIndex는 0', () => {
-      const folder = new Folder(TITLE);
+      const folder = new Folder({ title: TITLE });
 
       todoStore.addFolder(folder);
 
@@ -25,8 +25,8 @@ describe('TodoStore', () => {
     });
 
     it('두 개를 추가하는 경우 selectedFolderIndex는 1', () => {
-      todoStore.addFolder(new Folder(TITLE));
-      todoStore.addFolder(new Folder(TITLE));
+      todoStore.addFolder(new Folder({ title: TITLE }));
+      todoStore.addFolder(new Folder({ title: TITLE }));
 
       expect(todoStore.snapshot.folders.length).toBe(2);
       expect(todoStore.snapshot.selectedFolderIndex).toBe(1);
@@ -35,7 +35,7 @@ describe('TodoStore', () => {
     it('n 개를 추가하는 경우 selectedFolderIndex는 n-1', () => {
       const n = 100;
       for (let i = 0; i < n; i++) {
-        todoStore.addFolder(new Folder(TITLE));
+        todoStore.addFolder(new Folder({ title: TITLE }));
       }
 
       expect(todoStore.snapshot.folders.length).toBe(n);
@@ -45,7 +45,7 @@ describe('TodoStore', () => {
 
   context('when removeFolder', () => {
     it('1개에서 1개를 제거하는 경우 selectedFolderIndex는 null', () => {
-      const folder = new Folder(TITLE);
+      const folder = new Folder({ title: TITLE });
 
       todoStore.addFolder(folder);
 
@@ -59,8 +59,8 @@ describe('TodoStore', () => {
     });
 
     it('2개에서 1개를 제거하는 경우 selectedFolderIndex는 0', () => {
-      const folder = new Folder(TITLE);
-      const folder2 = new Folder(TITLE);
+      const folder = new Folder({ title: TITLE });
+      const folder2 = new Folder({ title: TITLE });
 
       todoStore.addFolder(folder);
       todoStore.addFolder(folder2);
@@ -77,28 +77,28 @@ describe('TodoStore', () => {
 
   context('when addFolder and removeFolder', () => {
     it('1개를 추가하고 1개를 삭제하고 한개를 추가하는 경우 selectedFolderIndex는 0', () => {
-      const folder = new Folder(TITLE);
+      const folder = new Folder({ title: TITLE });
       expect(todoStore.snapshot.folders.length).toBe(0);
       todoStore.addFolder(folder);
       expect(todoStore.snapshot.folders.length).toBe(1);
       todoStore.removeFolder(folder);
       expect(todoStore.snapshot.folders.length).toBe(0);
 
-      const folder2 = new Folder(TITLE);
+      const folder2 = new Folder({ title: TITLE });
       todoStore.addFolder(folder2);
 
       expect(todoStore.snapshot.folders.length).toBe(1);
       expect(todoStore.snapshot.selectedFolderIndex).toBe(0);
     });
     it('2개를 추가하고 1개를 삭제하고 1개를 추가하는 경우 selectedFolderIndex는 1', () => {
-      const folder = new Folder(TITLE);
+      const folder = new Folder({ title: TITLE });
       todoStore.addFolder(folder);
-      const folder2 = new Folder(TITLE);
+      const folder2 = new Folder({ title: TITLE });
       todoStore.addFolder(folder2);
 
       todoStore.removeFolder(folder);
 
-      const folder3 = new Folder(TITLE);
+      const folder3 = new Folder({ title: TITLE });
       todoStore.addFolder(folder3);
 
       expect(todoStore.snapshot.folders.length).toBe(2);
@@ -107,7 +107,7 @@ describe('TodoStore', () => {
   });
 
   it('addTask', () => {
-    todoStore.addFolder(new Folder(TITLE));
+    todoStore.addFolder(new Folder({ title: TITLE }));
     todoStore.addTask(todoStore.snapshot.folders[0], new Task({ title: TITLE }));
 
     const task = todoStore.snapshot.folders[0].tasks[0];
@@ -117,7 +117,7 @@ describe('TodoStore', () => {
   });
 
   it('removeTask', () => {
-    todoStore.addFolder(new Folder(TITLE));
+    todoStore.addFolder(new Folder({ title: TITLE }));
     todoStore.addTask(todoStore.snapshot.folders[0], new Task({ title: TITLE }));
 
     todoStore.removeTask(todoStore.snapshot.folders[0], todoStore.snapshot.folders[0].tasks[0]);
@@ -126,7 +126,7 @@ describe('TodoStore', () => {
   });
 
   it('toggleTask', () => {
-    todoStore.addFolder(new Folder(TITLE));
+    todoStore.addFolder(new Folder({ title: TITLE }));
     todoStore.addTask(todoStore.snapshot.folders[0], new Task({ title: TITLE }));
 
     expect(todoStore.snapshot.folders[0].tasks[0].isCompleted).toBeFalsy();
@@ -138,9 +138,9 @@ describe('TodoStore', () => {
 
   context('when getter, setter', () => {
     it('set selectedFolderIndex', () => {
-      const folder = new Folder(TITLE);
-      const folder2 = new Folder(TITLE);
-      const folder3 = new Folder(TITLE);
+      const folder = new Folder({ title: TITLE });
+      const folder2 = new Folder({ title: TITLE });
+      const folder3 = new Folder({ title: TITLE });
 
       todoStore.addFolder(folder);
       todoStore.addFolder(folder2);

--- a/packages/client-todo-list/src/store/TodoStore.spec.ts
+++ b/packages/client-todo-list/src/store/TodoStore.spec.ts
@@ -146,13 +146,13 @@ describe('TodoStore', () => {
 
       expect(todoStore.snapshot.selectedFolderId).toBe(todoStore.snapshot.folders[2].id);
 
-      todoStore.setSelectedFolderIndex(0);
+      todoStore.setSelectedFolderId(0);
       expect(todoStore.snapshot.selectedFolderId).toBe(0);
 
-      todoStore.setSelectedFolderIndex(1);
+      todoStore.setSelectedFolderId(1);
       expect(todoStore.snapshot.selectedFolderId).toBe(1);
 
-      todoStore.setSelectedFolderIndex(2);
+      todoStore.setSelectedFolderId(2);
       expect(todoStore.snapshot.selectedFolderId).toBe(2);
     });
   });

--- a/packages/client-todo-list/src/store/TodoStore.spec.ts
+++ b/packages/client-todo-list/src/store/TodoStore.spec.ts
@@ -33,7 +33,7 @@ describe('TodoStore', () => {
 
       expect(todoStore.snapshot.folders.length).toBe(n);
 
-      expect(todoStore.snapshot.selectedFolderId).toBe(todoStore.snapshot.folders.at(-1)?.id);
+      expect(todoStore.snapshot.selectedFolderId).toBe(getLastFolderId(todoStore));
     });
   });
 
@@ -62,7 +62,7 @@ describe('TodoStore', () => {
       todoStore.removeFolder(folder);
 
       expect(todoStore.snapshot.folders.length).toBe(1);
-      expect(todoStore.snapshot.selectedFolderId).toBe(todoStore.snapshot.folders.at(-1)?.id);
+      expect(todoStore.snapshot.selectedFolderId).toBe(getLastFolderId(todoStore));
     });
   });
 
@@ -79,7 +79,7 @@ describe('TodoStore', () => {
       todoStore.addFolder(folder2);
 
       expect(todoStore.snapshot.folders.length).toBe(1);
-      expect(todoStore.snapshot.selectedFolderId).toBe(todoStore.snapshot.folders.at(-1)?.id);
+      expect(todoStore.snapshot.selectedFolderId).toBe(getLastFolderId(todoStore));
     });
     it('2개를 추가하고 1개를 삭제하고 1개를 추가하는 경우 selectedFolderId는 마지막 folder id', () => {
       const folder = new Folder({ title: TITLE });
@@ -93,7 +93,7 @@ describe('TodoStore', () => {
       todoStore.addFolder(folder3);
 
       expect(todoStore.snapshot.folders.length).toBe(2);
-      expect(todoStore.snapshot.selectedFolderId).toBe(todoStore.snapshot.folders.at(-1)?.id);
+      expect(todoStore.snapshot.selectedFolderId).toBe(getLastFolderId(todoStore));
     });
   });
 
@@ -156,3 +156,9 @@ describe('TodoStore', () => {
     expect(todoStore.currentFolder).toEqual(folder);
   });
 });
+
+const getLastFolderId = (todoStore: TodoStore) => {
+  const lastFolder = todoStore.snapshot.folders.at(-1);
+  if (!lastFolder) throw new Error('마지막 폴더가 없음');
+  return lastFolder.id;
+};

--- a/packages/client-todo-list/src/store/TodoStore.ts
+++ b/packages/client-todo-list/src/store/TodoStore.ts
@@ -6,21 +6,21 @@ import Task from 'models/Task';
 class TodoStore {
   private _folders: Folder[] = [];
   // TODO: selectedFolderId로 변경할 예정. 그 후에는 selectedFolder로 변경할 예정.
-  private _selectedFolderIndex: null | number = null;
+  private _selectedFolderId: null | number = null;
 
   @Action()
   public addFolder(folder: Folder) {
     this._folders = [...this._folders, folder];
-    this._selectedFolderIndex = folder.id;
+    this._selectedFolderId = folder.id;
   }
 
   @Action()
   public removeFolder(folder: Folder) {
     this._folders = this._folders.filter((_folder) => _folder !== folder);
     if (this._folders.length) {
-      this._selectedFolderIndex = this._folders[0].id;
+      this._selectedFolderId = this._folders[0].id;
     } else {
-      this._selectedFolderIndex = null;
+      this._selectedFolderId = null;
     }
   }
 
@@ -56,7 +56,7 @@ class TodoStore {
 
   @Action()
   public setSelectedFolderIndex(selectedFolderIndex: number | null) {
-    this._selectedFolderIndex = selectedFolderIndex;
+    this._selectedFolderId = selectedFolderIndex;
   }
 
   private findFolder(folder: Folder) {
@@ -67,7 +67,7 @@ class TodoStore {
   public get snapshot() {
     return {
       folders: this._folders,
-      selectedFolderIndex: this._selectedFolderIndex,
+      selectedFolderIndex: this._selectedFolderId,
     };
   }
 }

--- a/packages/client-todo-list/src/store/TodoStore.ts
+++ b/packages/client-todo-list/src/store/TodoStore.ts
@@ -5,19 +5,20 @@ import Task from 'models/Task';
 @Store()
 class TodoStore {
   private _folders: Folder[] = [];
+  // TODO: selectedFolderId로 변경할 예정. 그 후에는 selectedFolder로 변경할 예정.
   private _selectedFolderIndex: null | number = null;
 
   @Action()
   public addFolder(folder: Folder) {
     this._folders = [...this._folders, folder];
-    this._selectedFolderIndex = this._folders.indexOf(folder);
+    this._selectedFolderIndex = folder.id;
   }
 
   @Action()
   public removeFolder(folder: Folder) {
     this._folders = this._folders.filter((_folder) => _folder !== folder);
     if (this._folders.length) {
-      this._selectedFolderIndex = 0;
+      this._selectedFolderIndex = this._folders[0].id;
     } else {
       this._selectedFolderIndex = null;
     }

--- a/packages/client-todo-list/src/store/TodoStore.ts
+++ b/packages/client-todo-list/src/store/TodoStore.ts
@@ -67,7 +67,7 @@ class TodoStore {
   public get snapshot() {
     return {
       folders: this._folders,
-      selectedFolderIndex: this._selectedFolderId,
+      selectedFolderId: this._selectedFolderId,
     };
   }
 }

--- a/packages/client-todo-list/src/store/TodoStore.ts
+++ b/packages/client-todo-list/src/store/TodoStore.ts
@@ -55,7 +55,7 @@ class TodoStore {
   }
 
   @Action()
-  public setSelectedFolderIndex(selectedFolderIndex: number | null) {
+  public setSelectedFolderId(selectedFolderIndex: number | null) {
     this._selectedFolderId = selectedFolderIndex;
   }
 

--- a/packages/client-todo-list/src/store/TodoStore.ts
+++ b/packages/client-todo-list/src/store/TodoStore.ts
@@ -5,7 +5,6 @@ import Task from 'models/Task';
 @Store()
 class TodoStore {
   private _folders: Folder[] = [];
-  // TODO: selectedFolderId로 변경할 예정. 그 후에는 selectedFolder로 변경할 예정.
   private _selectedFolderId: null | number = null;
 
   @Action()
@@ -63,7 +62,6 @@ class TodoStore {
     return this._folders.find((v) => v === folder);
   }
 
-  // TODO: 스냅샷이 필요할까? 그냥 getter만 쓰면 어떨까 혹은 멤버변수를 public으로 관리하면 어떨까...
   public get snapshot() {
     return {
       folders: this._folders,

--- a/packages/client-todo-list/src/store/TodoStore.ts
+++ b/packages/client-todo-list/src/store/TodoStore.ts
@@ -68,6 +68,10 @@ class TodoStore {
       selectedFolderId: this._selectedFolderId,
     };
   }
+
+  public get currentFolder() {
+    return this._folders.find((folder) => folder.id === this._selectedFolderId);
+  }
 }
 
 export default TodoStore;


### PR DESCRIPTION
## 개요 및 변경 사항 <!-- 필수 -->

- useStore를 mutable하게 관리했었는데 immutable하게 관리하게 수정
- areEqual로직을 원상복구
- Folder, Task에 id 추가, 컴포넌트 map에서 key를 index에서 id로 변경
- TodoStore에 currentFolder라는 getter 생성
- TodoStore의 selectedIndex를 selectedId로 변경
- Folder 클래스의 생성자에 넣는 값을 객체로 변경
- 컴포넌트 분리

## 이슈번호 <!-- 필수 -->

## 참고사항

- 라이브러리를 구현하신 분과의 질문답변 https://github.com/seed2whale/usestore-ts/issues/1
- immutable로 구현하면서 구현방법이 조금 어려워졌음.
- 책에서 배운 리팩터링을 기반으로 리팩터링(커밋 잘게 나누기, 테스트코드 등등)
- 개인적인 고민

TodoList컴포넌트에서 store에서 접근하는 값이나 data를 props로 전달하는게 좋을지 고민중
container, presentational 컴포넌트 개념은 현재 사용되지 않는게 맞긴함
하지만 ui와 데이터를 분리하는 행동은 의미가 있음(물론 store에서 실질적인 로직이 있기 때문에 분리되어 있다고 볼수도 있기는 함)
이 ui를 다른곳에서 재사용한다면 디자인 컴포넌트처럼 props를 넘겨주는게 좋음.
but 지금은 구현할 때 도메인에 종속적이라고 생각하고 재사용할거라고 생각해서 만들지 않음
만약 모든 경우를 데이터와 ui를 분리하게 된다면 그건 시간이 배로 소요가 됨.
속도가 중요한 웹 프론트엔드에서는 그걸 안고 갈 수 없음.
근데 VAC패턴 관점에서 생각해보면 이것도 틀린방식은 아님
일단은 props를 넘기지 말고 컴포넌트내부에서 커스텀훅으로 데이터를 관리하는 방식을 선택함.
추후에 리덕스로도 이걸 똑같이 구현해볼건데 그때는 그냥 기존 코드를 복사해서 적절히 사용할 예정
재사용하기 위해 데이터를 분리할 수도 있지만 이건 연습용이라서 ui가 같을뿐 실제 상황과는 다르다고 생각하기 때문

## 추가 구현 필요사항

- useStore에 스토리북을 적용하는 방법, devtool용 라이브러리나 크롬익스텐션 구현
- 리덕스로 테스트

## 스크린샷 or gif <!-- 변경이전과 변경후의 사진. 애니메이션이면 gif를 올리면 더 좋아요. https://ezgif.com/video-to-gif -->
